### PR TITLE
X01BD : sepolicy: Fix bootloop on TWRP restore

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -767,4 +767,7 @@
     <!-- Smart Charing is available -->
     <bool name="config_smartChargingAvailable">true</bool>
 
+    <!-- True if the device supports system navigation keys. -->
+    <bool name="config_supportSystemNavigationKeys">true</bool>
+
 </resources>

--- a/sepolicy/vendor/zygote.te
+++ b/sepolicy/vendor/zygote.te
@@ -1,0 +1,1 @@
+allow zygote system_file:dir mounton;


### PR DESCRIPTION
X01BD : sepolicy: Fix bootloop on TWRP restore

When TWRP restores a ROM backup, the root directory now has the wrong
selinux
context "system_file" instead of "rootfs" as it should be for Q
system-as-root.

Attempting to boot the restored ROM results in the following
error/denial
and will bootloop if the ROM is enforcing.

zygote  : jni_internal.cc:811] JNI FatalError called:
frameworks/base/core/jni/com_android_internal_os_Zygote.cpp:1315:
Failed to mount() rootfs as MS_SLAVE

auditd  : type=1400 audit(0.0:9): avc: denied { mounton } for uid=0
comm="main" path="/" dev="mmcblk0p41"
ino=2 scontext=u:r:zygote:s0 tcontext=u:object_r:system_file:s0
tclass=dir permissive=0
main    : type=1400 audit(0.0:9): avc: denied { mounton } for uid=0
path="/" dev="mmcblk0p41"
ino=2 scontext=u:r:zygote:s0 tcontext=u:object_r:system_file:s0
tclass=dir permissive=0

This rule fixes the resulting denial.
A proper fix would be to set the correct context for the system mount
point during the restore process for Q based roms.

Change-Id: Ia730ac1f48a88516726a3004e1796401df141c71